### PR TITLE
Development

### DIFF
--- a/Sources/FNLNexus/NetworkClient/FNLDefaultHTTPClient.swift
+++ b/Sources/FNLNexus/NetworkClient/FNLDefaultHTTPClient.swift
@@ -32,7 +32,7 @@ public final class FNLDefaultHTTPClient {
     ///   - decoder: A `FNLDataDecoder` used to decode the response data. Defaults to `JSONDecoder()`.
     public init(
         session: URLSession = .shared,
-        requestBuilder: FNLRequestBuildable,
+        requestBuilder: FNLRequestBuildable = FNLRequestBuilder(),
         decoder: FNLDataDecoder = JSONDecoder()
     ) {
         self.session = session

--- a/Sources/FNLNexus/NetworkClient/FNLDefaultHTTPClient.swift
+++ b/Sources/FNLNexus/NetworkClient/FNLDefaultHTTPClient.swift
@@ -8,12 +8,12 @@
 import Foundation
 import Combine
 
-/// A default implementation of `FNLHTTPClient` that uses `URLSession` to perform HTTP requests.
+/// A default implementation of `FNLHTTPClient` that uses `URLSession` to perform HTTP requests, it`s being used from the exntension providing a default implemtantion so there is no need to make it public.
 ///
 /// This client is built to work with a custom `FNLRequestBuildable` request builder
 /// and a `FNLDataDecoder` for decoding responses. It supports raw response fetching
 /// and strongly typed decoding using Swift's `Codable`.
-public final class FNLDefaultHTTPClient {
+final class FNLDefaultHTTPClient {
     
     /// The URL session used to perform network requests.
     public let session: URLSession

--- a/Tests/FNLNexusTests/Helpers/Helpers.swift
+++ b/Tests/FNLNexusTests/Helpers/Helpers.swift
@@ -6,6 +6,7 @@
 //
 
 import Foundation
+import FNLNexus
 
 func anyData() -> Data {
     return Data("any data".utf8)
@@ -17,6 +18,10 @@ func anyNSError() -> NSError {
 
 func anyURL() -> URL {
     return URL(string: "http://a-url.com")!
+}
+
+func anyEndpoint() -> FNLEndpoint {
+    return MockEndpoint()
 }
 
 func anyHTTPURLResponse() -> HTTPURLResponse {

--- a/Tests/FNLNexusTests/Helpers/MockEndpoint.swift
+++ b/Tests/FNLNexusTests/Helpers/MockEndpoint.swift
@@ -9,29 +9,29 @@ import FNLNexus
 import Foundation
 
 struct MockEndpoint: FNLEndpoint {
-        var method: FNLRequestMethod
-        var headers: Header?
-        var scheme: FNLScheme
-        var host: String
-        var path: String
-        var body: FNLNexus.FNLBodyParameter?
-        var params: [URLQueryItem]?
-        
-        init(
-            method: FNLRequestMethod = .get,
-            headers: Header? = nil,
-            scheme: FNLScheme = .https,
-            host: String = "api.example.com",
-            path: String = "/test",
-            body: FNLBodyParameter? = nil,
-            params: [URLQueryItem]? = nil
-        ) {
-            self.method = method
-            self.headers = headers
-            self.scheme = scheme
-            self.host = host
-            self.path = path
-            self.body = body
-            self.params = params
-        }
+    var method: FNLRequestMethod
+    var headers: Header?
+    var scheme: FNLScheme
+    var host: String
+    var path: String
+    var body: FNLNexus.FNLBodyParameter?
+    var params: [URLQueryItem]?
+    
+    init(
+        method: FNLRequestMethod = .get,
+        headers: Header? = nil,
+        scheme: FNLScheme = .https,
+        host: String = "api.example.com",
+        path: String = "/test",
+        body: FNLBodyParameter? = nil,
+        params: [URLQueryItem]? = nil
+    ) {
+        self.method = method
+        self.headers = headers
+        self.scheme = scheme
+        self.host = host
+        self.path = path
+        self.body = body
+        self.params = params
     }
+}

--- a/Tests/FNLNexusTests/NetworkClient/FNLDefaultHTTPClientTests.swift
+++ b/Tests/FNLNexusTests/NetworkClient/FNLDefaultHTTPClientTests.swift
@@ -17,7 +17,6 @@ final class FNLDefaultHTTPClientTests: XCTestCase {
         await URLProtocolStub.removeStub()
     }
     
-    
     // MARK: - Helpers
     private func makeSUT(file: StaticString = #filePath,
                          line: UInt = #line) -> FNLHTTPCleint {


### PR DESCRIPTION
feat: Provided default async and combine implementations for `FNLHTTPCleint` methods using `FNLDefaultHTTPClient`.

Allows conforming types to get basic request handling out-of-the-box without re-implementing common logic.